### PR TITLE
ci: define explicit permissions for workflows

### DIFF
--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: master
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Check which files changed

--- a/.github/workflows/delete_devices.yaml
+++ b/.github/workflows/delete_devices.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '49 5 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   TERM: xterm
 

--- a/.github/workflows/frida.yaml
+++ b/.github/workflows/frida.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: frida
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   TERM: xterm
   CORELLIUM_INSTANCE_NAME_PREFIX: 'Frida Automation'

--- a/.github/workflows/install_npm_deps.yaml
+++ b/.github/workflows/install_npm_deps.yaml
@@ -3,6 +3,9 @@ name: Install NPM dependencies
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bump-deps:
     name: Install NPM deps on self-hosted runner

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: none
 
 jobs:
   changes-lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   changes-lint:
     name: Determine files to lint

--- a/.github/workflows/matrix_with_appium.yaml
+++ b/.github/workflows/matrix_with_appium.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.event_name == 'schedule' && 'corellium-matrix-scheduled' || 'corellium-matrix-development' }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   TERM: xterm
   VPN_CONFIG_PATH: /home/runner/my_vpn_config.ovpn

--- a/.github/workflows/start_devices.yaml
+++ b/.github/workflows/start_devices.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '50 10 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   TERM: xterm
 

--- a/.github/workflows/stop_devices.yaml
+++ b/.github/workflows/stop_devices.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '2 23 * * 1-5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   TERM: xterm
 


### PR DESCRIPTION
Potential fix for [https://github.com/davidcbacker/automatecorellium/security/code-scanning/44](https://github.com/davidcbacker/automatecorellium/security/code-scanning/44)

Add an explicit `permissions` block in `.github/workflows/stop_devices.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (checkout requires read access to repository contents) while preventing unnecessary write scopes for `GITHUB_TOKEN`.

Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and `env:` (or anywhere at top-level before `jobs:`).

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
